### PR TITLE
Added optional unit parameter to kinetics

### DIFF
--- a/phreeqpython/solution.py
+++ b/phreeqpython/solution.py
@@ -139,7 +139,7 @@ class Solution(object):
         """ remove this solution from VIPhreeqc memory """
         self.pp.remove_solutions([self.number])
 
-    def kinetics(self, element, rate_function, time, m0=0, args=()):
+    def kinetics(self, element, rate_function, time, m0=0, args=(), unit="mmol"):
 
         def calc_rate(y, t, m0, *args):
             temp = self.copy()
@@ -154,7 +154,7 @@ class Solution(object):
 
         for i in range(len(time)):
             t = time[i]
-            self.add(element, y[i])
+            self.add(element, y[i], unit)
             yield(t, self)
 
     # Magic functions


### PR DESCRIPTION
It seems that the kinetic method always assumes that the rates returned by the rate_function are in mmol. 
