### PR TITLE
Improve __str__ representation of Solution class

### DIFF
--- a/phreeqpython/solution.py
+++ b/phreeqpython/solution.py
@@ -232,4 +232,4 @@ class Solution(object):
 
     # pretty printing
     def __str__(self):
-        return "<PhreeqPython.Solution."+self.__class__.__name__ + " with number '" + self.number + "'>"
+        return f"<PhreeqPython.{self.__class__.__name__} number {self.number}>"


### PR DESCRIPTION
In previous implementation it sometimes yields an error because the self.number is an int while the __str__ expects it to be a str. Now it uses f-strings instead which makes it more readable and the attributes are cast to a string-representation automatically. I also slightly changed the formatting to make it more concise. It now prints as `<PhreeqPython.Solution number 0>`

This especially solves issue we experience when we use the `PhreeqPython` `Solution`s in a `DataFrame` as we do in our tool [`HGC`](https://github.com/KWR-Water/hgc)